### PR TITLE
Various fixes

### DIFF
--- a/lib/Net/Async/Ping/ICMP.pm
+++ b/lib/Net/Async/Ping/ICMP.pm
@@ -151,7 +151,6 @@ sub ping {
                 } elsif ($from_type == ICMP_TIME_EXCEEDED) {
                     $f->fail('ICMP Timeout');
                 }
-                $legacy ? $loop->remove($self) : $ping->remove_child($self);
             },
         );
 
@@ -163,9 +162,14 @@ sub ping {
            $f,
            $loop->timeout_future(after => $timeout)
         )
-        ->then(
-            sub { Future->done(Time::HiRes::tv_interval($t0)) }
-        )
+        ->then( sub {
+            Future->done(Time::HiRes::tv_interval($t0))
+        })
+        ->followed_by( sub {
+            my $f = shift;
+            $socket->remove_from_parent;
+            $f;
+        })
     });
 }
 

--- a/lib/Net/Async/Ping/ICMP.pm
+++ b/lib/Net/Async/Ping/ICMP.pm
@@ -151,7 +151,7 @@ sub ping {
                 } elsif ($from_type == ICMP_TIME_EXCEEDED) {
                     $f->fail('ICMP Timeout');
                 }
-                $legacy ? $loop->remove($socket) : $ping->remove_child($socket);
+                $legacy ? $loop->remove($self) : $ping->remove_child($self);
             },
         );
 

--- a/lib/Net/Async/Ping/ICMP.pm
+++ b/lib/Net/Async/Ping/ICMP.pm
@@ -9,6 +9,7 @@ use Time::HiRes;
 use Carp;
 use Net::Ping;
 use IO::Async::Socket;
+use Scalar::Util qw/blessed/;
 
 use Socket qw( SOCK_RAW SOCK_DGRAM AF_INET NI_NUMERICHOST inet_aton pack_sockaddr_in unpack_sockaddr_in getnameinfo inet_ntop);
 
@@ -68,7 +69,7 @@ sub configure_unknown
 sub ping {
     my $self = shift;
     # Maintain compat with old API
-    my $legacy = ref $_[0] eq 'IO::Async::Loop::Poll';
+    my $legacy = blessed $_[0] and $_[0]->isa('IO::Async::Loop');
     my $loop   = $legacy ? shift : $self->loop;
 
     my ($host, $timeout) = @_;

--- a/lib/Net/Async/Ping/ICMP.pm
+++ b/lib/Net/Async/Ping/ICMP.pm
@@ -83,13 +83,13 @@ sub ping {
     # Let's try a ping socket (unprivileged ping) first. See
     # https://lwn.net/Articles/422330/
     my ($ping_socket, $ident);
-    if ($self->use_ping_socket && socket($fh, AF_INET, SOCK_DGRAM, $proto_num))
+    if ($self->use_ping_socket && $fh->socket(AF_INET, SOCK_DGRAM, $proto_num))
     {
         $ping_socket = 1;
         ($ident) = unpack_sockaddr_in getsockname($fh);
     }
     else {
-        socket($fh, AF_INET, SOCK_RAW, $proto_num) ||
+        $fh->socket(AF_INET, SOCK_RAW, $proto_num) ||
             croak("Unable to create ICMP socket ($!). Are you running as root?"
               ." If not, and your system supports ping sockets, try setting"
               ." /proc/sys/net/ipv4/ping_group_range");

--- a/lib/Net/Async/Ping/TCP.pm
+++ b/lib/Net/Async/Ping/TCP.pm
@@ -7,6 +7,7 @@ use Carp qw/croak/;
 use Future;
 use POSIX 'ECONNREFUSED';
 use Time::HiRes;
+use Scalar::Util qw/blessed/;
 
 extends 'IO::Async::Notifier';
 
@@ -40,7 +41,7 @@ sub configure_unknown
 sub ping {
     my $self = shift;
     # Maintain compat with old API
-    my $legacy = ref $_[0] eq 'IO::Async::Loop::Poll';
+    my $legacy = blessed $_[0] and $_[0]->isa('IO::Async::Loop');
     my $loop   = $legacy ? shift : $self->loop;
 
    my ($host, $timeout) = @_;

--- a/t/icmp.t
+++ b/t/icmp.t
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+
+use lib '.';
+use t::test;
+
+t::test::run_tests('icmp');

--- a/t/icmp.t
+++ b/t/icmp.t
@@ -1,7 +1,11 @@
 use strict;
 use warnings;
 
+use Test::More;
+
 use lib '.';
 use t::test;
+
+plan skip_all => "Not running as root; skipping ICMP raw socket pings" if $>;
 
 t::test::run_tests('icmp');

--- a/t/icmp_ps.t
+++ b/t/icmp_ps.t
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+
+use lib '.';
+use t::test;
+
+t::test::run_tests('icmp_ps');

--- a/t/icmp_ps.t
+++ b/t/icmp_ps.t
@@ -1,7 +1,24 @@
 use strict;
 use warnings;
 
+use Test::More;
+
 use lib '.';
 use t::test;
+
+# Tricky: try and see if this user can use ping sockets
+plan skip_all => "Not Linux: skipping ping socket tests" unless $^O =~ /linux/;
+
+my $proc = '/proc/sys/net/ipv4/ping_group_range';
+open(my $fh, '<', $proc)
+    or plan skip_all => "Cannot open $proc ($!): skipping ping socket tests";
+
+my $groups = <$fh>;
+defined $groups
+    or plan skip_all => "/proc/sys/net/ipv4/ping_group_range is empty: skipping ping socket tests";
+$groups =~ /^([0-9]+)\h+([0-9]+)$/
+    or plan skip_all => "Cannot parse /proc/sys/net/ipv4/ping_group_range: skipping ping socket tests";
+$1 <= $) && $2 >= $)
+    or plan skip_all => "Current user's group is not allowed to use ping sockets: skipping ping socket tests";
 
 t::test::run_tests('icmp_ps');

--- a/t/tcp.t
+++ b/t/tcp.t
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+
+use lib '.';
+use t::test;
+
+t::test::run_tests('tcp');

--- a/t/test.pm
+++ b/t/test.pm
@@ -1,3 +1,5 @@
+package t::test;
+
 use strict;
 use warnings;
 
@@ -10,8 +12,10 @@ use Test::Fatal;
 
 my $expected = 0; # Expected number of tests, adjusted as we go
 
-foreach my $type (qw/tcp icmp icmp_ps/) # Normal ICMP and ICMP with ping socket
+sub run_tests
 {
+    my ($type) = @_;
+
     SKIP: {
 
         # Horribly hacky. We guess what might be an unreachable address, and
@@ -107,7 +111,9 @@ foreach my $type (qw/tcp icmp icmp_ps/) # Normal ICMP and ICMP with ping socket
             $expected += 5; # 5 tests above, not including unreachable
         }
     }
+
+    done_testing($expected);
 }
 
 
-done_testing($expected);
+1;

--- a/t/test.pm
+++ b/t/test.pm
@@ -16,100 +16,82 @@ sub run_tests
 {
     my ($type) = @_;
 
-    SKIP: {
+    # Horribly hacky. We guess what might be an unreachable address, and
+    # see whether it actually is with a call to the external ping command.
+    # We do this now, so we know how many tests we need to skip.
+    my $unreach         = '192.168.0.197';
+    my $return          = qx(ping -c 1 $unreach) || '';
+    my $has_unreachable = $return =~ /Destination Host Unreachable/;
 
-        # Horribly hacky. We guess what might be an unreachable address, and
-        # see whether it actually is with a call to the external ping command.
-        # We do this now, so we know how many tests we need to skip.
-        my $unreach         = '192.168.0.197';
-        my $return          = qx(ping -c 1 $unreach) || '';
-        my $has_unreachable = $return =~ /Destination Host Unreachable/;
+    my %options;
+    if ($type eq 'icmp') {
+        %options = (use_ping_socket => 0);
+    }
+    elsif ($type eq 'icmp_ps') {
+        %options = (use_ping_socket => 1); # default
+    }
 
-        my %options;
-        if ($type eq 'icmp') {
-            my $skip = $has_unreachable ? 12 : 10;
-            # Skipping still counts as a test, increment $expected
-            ++$expected && skip "Not running as root: skipping ICMP raw socket pings" if $>;
-            %options = (use_ping_socket => 0);
-        }
-        elsif ($type eq 'icmp_ps') {
-            # Tricky: try and see if this user can use ping sockets
-            ++$expected && skip "Not Linux: skipping ping socket tests" unless $^O =~ /linux/;
-            my $proc = '/proc/sys/net/ipv4/ping_group_range';
-            open(my $fh, '<', $proc)
-                or ++$expected && skip "Cannot open $proc ($!): skipping ping socket tests";
-            my $groups = <$fh>;
-            defined $groups
-                or ++$expected && skip "/proc/sys/net/ipv4/ping_group_range is empty: skipping ping socket tests";
-            $groups =~ /^([0-9]+)\h+([0-9]+)$/
-                or ++$expected && skip "Cannot parse /proc/sys/net/ipv4/ping_group_range: skipping ping socket tests";
-            $1 <= $) && $2 >= $)
-                or ++$expected && skip "Current user's group is not allowed to use ping sockets: skipping ping socket tests";
-            %options = (use_ping_socket => 1); # default
-        }
+    # Test old and new API (with and without $loop)
+    foreach my $legacy (0..1)
+    {
+        my $t = $type eq 'icmp_ps' ? 'icmp' : $type;
+        my $p = Net::Async::Ping->new($t => { default_timeout => 1, %options });
+        my $l = IO::Async::Loop->new;
+        $l->add($p) if !$legacy;
 
-        # Test old and new API (with and without $loop)
-        foreach my $legacy (0..1)
+        my @params = $legacy ? ($l, 'localhost') : ('localhost');
+        $p->ping(@params)
+           ->then(sub {
+              pass "type: $type, legacy: $legacy, pinged localhost!";
+              note("success future: @_");
+              Future->done
+           })->else(sub {
+              fail "type: $type, legacy: $legacy, pinged localhost!";
+              note("failure future: @_");
+              Future->fail('failed to ping localhost!')
+           })->get;
+
+        # http://en.wikipedia.org/wiki/Reserved_IP_addresses
+        @params = $legacy ? ($l, '192.0.2.0') : ('192.0.2.0');
+        my $f = $p->ping(@params)
+           ->then(sub {
+              fail qq(type: $type, legacy: $legacy, couldn't reach 192.0.2.0);
+              note("success future: @_");
+              Future->done
+           })->else(sub {
+              pass qq(type: $type, legacy: $legacy, couldn't reach 192.0.2.0);
+              note("failure future: @_");
+              Future->fail('expected failure')
+           });
+        like exception { $f->get }, qr/expected failure/, 'expected failure';
+
+        if ($type eq 'icmp') # Unreachable replies do not seem to work with ping sockets
         {
-            my $t = $type eq 'icmp_ps' ? 'icmp' : $type;
-            my $p = Net::Async::Ping->new($t => { default_timeout => 1, %options });
-            my $l = IO::Async::Loop->new;
-            $l->add($p) if !$legacy;
-
-            my @params = $legacy ? ($l, 'localhost') : ('localhost');
-            $p->ping(@params)
-               ->then(sub {
-                  pass "type: $type, legacy: $legacy, pinged localhost!";
-                  note("success future: @_");
-                  Future->done
-               })->else(sub {
-                  fail "type: $type, legacy: $legacy, pinged localhost!";
-                  note("failure future: @_");
-                  Future->fail('failed to ping localhost!')
-               })->get;
-
-            # http://en.wikipedia.org/wiki/Reserved_IP_addresses
-            @params = $legacy ? ($l, '192.0.2.0') : ('192.0.2.0');
-            my $f = $p->ping(@params)
-               ->then(sub {
-                  fail qq(type: $type, legacy: $legacy, couldn't reach 192.0.2.0);
-                  note("success future: @_");
-                  Future->done
-               })->else(sub {
-                  pass qq(type: $type, legacy: $legacy, couldn't reach 192.0.2.0);
-                  note("failure future: @_");
-                  Future->fail('expected failure')
-               });
-            like exception { $f->get }, qr/expected failure/, 'expected failure';
-
-            if ($type eq 'icmp') # Unreachable replies do not seem to work with ping sockets
-            {
-                SKIP: {
-                    ++$expected && skip "$unreach is not unreachable: skipping unreachable IP address tests"
-                        unless $has_unreachable;
-                    @params = $legacy ? ($l, $unreach) : ($unreach);
-                    my $f = $p->ping(@params, 5); # Longer timeout needed for unreachable packets
-                    like exception { $f->get }, qr/ICMP Unreachable/, "type: $type, legacy: $legacy, expected failure";
-                    $expected++;
-                }
+            SKIP: {
+                ++$expected && skip "$unreach is not unreachable: skipping unreachable IP address tests"
+                    unless $has_unreachable;
+                @params = $legacy ? ($l, $unreach) : ($unreach);
+                my $f = $p->ping(@params, 5); # Longer timeout needed for unreachable packets
+                like exception { $f->get }, qr/ICMP Unreachable/, "type: $type, legacy: $legacy, expected failure";
+                $expected++;
             }
-
-            # RFC6761, invalid domain to check resolver failure
-            @params = $legacy ? ($l, 'nothing.invalid') : ('nothing.invalid');
-            $f = $p->ping(@params)
-               ->then(sub {
-                  fail qq(type: $type, legacy: $legacy, couldn't reach nothing.invalid);
-                  note("success future: @_");
-                  Future->done
-               })->else(sub {
-                  pass qq(type: $type, legacy: $legacy, couldn't reach nothing.invalid);
-                  note("failure future: @_");
-                  Future->fail('expected failure')
-               });
-
-            like exception { $f->get }, qr/expected failure/, "type: $type, legacy: $legacy, expected failure";
-            $expected += 5; # 5 tests above, not including unreachable
         }
+
+        # RFC6761, invalid domain to check resolver failure
+        @params = $legacy ? ($l, 'nothing.invalid') : ('nothing.invalid');
+        $f = $p->ping(@params)
+           ->then(sub {
+              fail qq(type: $type, legacy: $legacy, couldn't reach nothing.invalid);
+              note("success future: @_");
+              Future->done
+           })->else(sub {
+              pass qq(type: $type, legacy: $legacy, couldn't reach nothing.invalid);
+              note("failure future: @_");
+              Future->fail('expected failure')
+           });
+
+        like exception { $f->get }, qr/expected failure/, "type: $type, legacy: $legacy, expected failure";
+        $expected += 5; # 5 tests above, not including unreachable
     }
 
     done_testing($expected);


### PR DESCRIPTION
 * Support other loop classes than `IO::Async::Loop::Poll`
 * Split tests into per-protocol files
   - more obvious skip reasons
   - ability to run just one for debugging
 * Neater removal of socket instances to avoid a filehandle leak